### PR TITLE
Remove filter of non-ascii characters in `RendererDxf.draw_text()`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Changes
 
+## Version 1.0.4
+
+_2026-03-10_
+
+Change:
+
+- Remove filter of non-ascii characters in `RendererDxf.draw_text()`. 
+  Let this be up to the caller if any filtering is needed.
+
 ## Version 1.0.3
 
 _2026-02-24_

--- a/mpldxf/backend_dxf.py
+++ b/mpldxf/backend_dxf.py
@@ -34,7 +34,6 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
-from __future__ import absolute_import, division, unicode_literals
 from io import BytesIO, StringIO
 import os
 import sys
@@ -49,8 +48,6 @@ from matplotlib.backend_bases import (
     FigureManagerBase,
 )
 from matplotlib.transforms import Affine2D
-import matplotlib.transforms as transforms
-import matplotlib.collections as mplc
 import numpy as np
 from shapely import Point
 from shapely.geometry import LineString, Polygon
@@ -817,9 +814,6 @@ class RendererDxf(RendererBase):
             dxfattribs["color"] = 256
         else:
             dxfattribs["color"] = rgb_to_dxf(gc.get_rgb())
-
-        s = s.replace("\u2212", "-")
-        s = s.encode("ascii", "ignore").decode()
 
         if s and len(s) > 0 and s[0] == "$":
             pattern = r"\\mathbf\{(.*?)\}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [tool.poetry]
 name = "mpldxf"
-version = "1.0.3"  
+version = "1.0.4"
 description = "A fork of mpldxf - a matplotlib backend to write DXF drawings. Modified by NGI to handle geotechnical plots"
 authors = ["David Kent",
            "Jon-Michael Josefsen <jmj@ngi.no>",
-           "Ingeborg Gjerde <ingeborg.gjerde@ngi.no>"]
+           "Ingeborg Gjerde <ingeborg.gjerde@ngi.no>",
+           "Jostein Leira <jostein@leira.net>"]
 license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/norwegian-geotechnical-institute/mpldxf-NGI"


### PR DESCRIPTION
- Old solutions strips away any non-ascii characters in strings sent to `RendererDxf.draw_text()`. This makes it hard to keep strings in other languages than English. It also makes it hard to find strings in the dxf structure, if you need to make any adjustments.
- Remove this restriction and let it be up to the caller if any stripping is needed.